### PR TITLE
Add transmission support for 802.15.4 modules

### DIFF
--- a/lib/xbee-promise.js
+++ b/lib/xbee-promise.js
@@ -17,6 +17,7 @@ var util = require('util');
 
 var optionsSpec = {
     serialport: 'required$, string$',
+    module: { enum$: ["802.15.4", "ZNet", "ZigBee", "Any"] },
     api_mode: { enum$: [1, 2] },
     serialportOptions: 'object$',
     defaultTimeout: { gt$: 1000, type$: 'integer' }
@@ -30,7 +31,8 @@ module.exports = function xbeePromiseLibrary(options) {
         serialport,
         cachedNodes = {},
         debug = false,
-        defaultTimeout;
+        defaultTimeout,
+        module;
 
 
     function closeSerialport() {
@@ -171,19 +173,33 @@ module.exports = function xbeePromiseLibrary(options) {
             });
     }
 
-
-    function _remoteTransmit(destination64, data, timeoutMs) {
+    function _remoteTransmit(destination64, destination16, data, timeoutMs) {
         var frame = {
-                type: xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_REQUEST,
-                destination64: destination64,
-                data: data
-            };
-
-        if (debug) {
-            console.log("Sending '" + data + "' to", destination64);
+            data: data,
+            type: xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_REQUEST
+        };
+        var responseFrame = xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS;
+        if (module == "802.15.4") {
+            responseFrame = xbee_api.constants.FRAME_TYPE.TX_STATUS;
+            if (destination64 != null) {
+                frame.type = xbee_api.constants.FRAME_TYPE.TX_REQUEST_64;
+                frame.destination64 = destination64;
+            } else {
+                frame.type = xbee_api.constants.FRAME_TYPE.TX_REQUEST_16;
+                frame.destination16 = destination16;
+            }
+        } else {
+            frame.destination64 = destination64;
+            if (destination16 != null) {
+              frame.destination16 = destination16;
+            }
         }
 
-        return _sendFramePromiseResponse(frame, timeoutMs, xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS)
+        if (debug) {
+            console.log("Sending '" + data + "' to", destination64, " / ", destination16);
+        }
+
+        return _sendFramePromiseResponse(frame, timeoutMs, responseFrame)
             .then(function (frame) {
                 if (frame.deliveryStatus === xbee_api.constants.DELIVERY_STATUS.SUCCESS) {
                     return true;
@@ -255,6 +271,9 @@ module.exports = function xbeePromiseLibrary(options) {
     }
 
 
+    // TODO test!
+    // TODO check length of destination16/64?
+    // TODO allow setting destination16 also for non-802.15.4 modules
     function remoteTransmit(settings) {
         var data,
             timeoutMs = (settings && settings.timeoutMs) || defaultTimeout;
@@ -269,19 +288,33 @@ module.exports = function xbeePromiseLibrary(options) {
             throw new Error("Settings property 'destination64' must be an array or a string");
         }
 
+        if (settings.destination16 && !util.isArray(settings.destination16) && typeof settings.destination16 !== "string") {
+            throw new Error("Settings property 'destination16' must be an array or a string");
+        }
+
         if (settings.destinationId && typeof settings.destinationId !== "string") {
             throw new Error("Settings property 'destinationId' must be a string");
         }
 
+        if (settings.destinationId && module == "802.15.4") {
+            throw new Error("Destination IDs not supported by 802.15.4 modules. Use 'destination16' or 'destination64' instead");
+        }
+
+        if (module == "802.15.4" && settings.destination64) {
+            return _remoteTransmit(settings.destination64, null, data, timeoutMs);
+        } else if (module == "802.15.4" && settings.destination16) {
+            return _remoteTransmit(null, settings.destination16, data, timeoutMs);
+        }
+        
         if (settings.destination64) {
-            return _remoteTransmit(settings.destination64, data, timeoutMs);
+            return _remoteTransmit(settings.destination64, null, data, timeoutMs);
         }
 
         if (settings.destinationId) {
             return _lookupByNodeIdentifier(settings.destinationId, timeoutMs)
                 .then(function (lookupResult) {
                     cachedNodes[settings.destinationId] = lookupResult;
-                    return _remoteTransmit(lookupResult, data, timeoutMs);
+                    return _remoteTransmit(lookupResult, null, data, timeoutMs);
                 });
         }
     }
@@ -299,7 +332,8 @@ module.exports = function xbeePromiseLibrary(options) {
     });
 
     xbeeAPI = new xbee_api.XBeeAPI({
-        api_mode: options.api_mode || 1
+        api_mode: options.api_mode || 1,
+        module: options.module || "Any"
     });
 
     options.serialportOptions.parser = xbeeAPI.rawParser();
@@ -315,6 +349,7 @@ module.exports = function xbeePromiseLibrary(options) {
         debug = true;
     }
 
+    module = options.module || "Any";
     defaultTimeout = options.defaultTimeout || 5000;
 
     if (debug) {


### PR DESCRIPTION
It shouldn't break compatibility - but since there are no tests, you maybe want to check by hand if it breaks anything before merging it.

So for those with Series 1/802.15.4 modules, just add `module: '802.15.4'` to the xbee-promise option array and be sure to use destination16/destination64 instead of destinationId when using `remoteTransmit`.
