### PR TITLE
Added support for remote asynchronous messages - sensors and switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,49 @@ xbee.remoteTransmit({
 });
 ```
 
+### Remote Monitor
+
+Asynchronous events originating in a remote device may be monitored using the remoteMonitor command. Examples of remote
+events are a switch is turned on, detected by the device and sent to the coordinator or a remote sensor sending periodic
+samples. When a message is received the promise will be resolved and the message will be sent to the deferred function.
+The data is contained in the `data` parameter. The  calling class is responsible for restarting the monitor after the
+message is received.
+
+```javascript
+
+var node = this;
+
+this.startMonitor = function() {
+    xbee.remoteMonitor()
+        .then(function(message){
+            node.handleMessage(message);
+        }).catch(function(err) {
+            console.log("Failed in monitor loop: " + err);
+        }).fin(function() {
+            // restart the monitor
+            node.startMonitor();
+        });
+};
+// Start the network monitor
+this.startMonitor();
+
+```
+### Remote Transmit - No Promise
+Messages may be sent to the remote network without a promise returned. This is useful in the case where the network is
+monitored through the remoteMonitor() method and a response needs to be sent to the device.
+
+```javascript
+this.handleMessage = function(message) {
+    var response = {response:"OK"};
+    var settings = {
+        destination64:device.serialNumber,
+        type: "ZIGBEE_TRANSMIT_REQUEST",
+        data: JSON.stringify(response)
+    };
+    this.xbee.remoteTransmitNoResponse(settings);
+}
+
+```
 Some more examples can be found in
 [the repository](https://github.com/101100/xbee-promise/tree/master/examples).
 

--- a/lib/xbee-promise.js
+++ b/lib/xbee-promise.js
@@ -156,8 +156,8 @@ module.exports = function xbeePromiseLibrary(options) {
     */
     function _monitorFramePromise(responseFrameType) {
 
-        var deferred = Q.defer();
-        var callback;
+        var deferred = Q.defer(), callback;
+
 
         console.log("Waiting for network messages");
         // Set the frame ID and create the callback to check for it
@@ -277,20 +277,19 @@ module.exports = function xbeePromiseLibrary(options) {
     */
     function _buildRemoteTransmitFrame(destination64, destination16, data) {
         var frame = {
-                    data: data,
-                    type: xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_REQUEST,
-                    destination64: destination64,
-                    destination16: destination16
-                },
-                responseFrameType = xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS;
+            data: data,
+            type: xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_REQUEST,
+            destination64: destination64,
+            destination16: destination16
+        },
 
-            if (module === "802.15.4") {
-                responseFrameType = xbee_api.constants.FRAME_TYPE.TX_STATUS;
+        if (module === "802.15.4") {
+            responseFrameType = xbee_api.constants.FRAME_TYPE.TX_STATUS;
                 frame.type = destination64 ?
-                        xbee_api.constants.FRAME_TYPE.TX_REQUEST_64 :
-                        xbee_api.constants.FRAME_TYPE.TX_REQUEST_16;
-            };
-            return frame;
+                xbee_api.constants.FRAME_TYPE.TX_REQUEST_64 :
+                xbee_api.constants.FRAME_TYPE.TX_REQUEST_16;
+        }
+        return frame;
     }
 
     /**
@@ -310,6 +309,8 @@ module.exports = function xbeePromiseLibrary(options) {
         if (debug) {
             console.log("Sending '" + data + "' to", destination64 || destination16);
         }
+
+        var responseFrameType = xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS;
 
         return _sendFramePromiseResponse(frame, timeoutMs, responseFrameType)
             .then(function (frame) {
@@ -352,7 +353,7 @@ module.exports = function xbeePromiseLibrary(options) {
      * @param destination16 the 16 bit address of the remote device
      * Note: Only one of the destinations should be defined with the other one undefined
      */
-    function _remoteTransmitNoResponse(destination64, destination16, data, timeoutMs) {
+    function _remoteTransmitNoResponse(destination64, destination16, data) {
 
         // Get the transmit frame
         var frame = _buildRemoteTransmitFrame(destination64, destination16, data);
@@ -510,31 +511,31 @@ module.exports = function xbeePromiseLibrary(options) {
     }
 
     function remoteTransmitNoResponse(settings) {
-            var data;
-            var timeoutMs = (settings && settings.timeoutMs) || defaultTimeoutMs;
+        var data;
+        var timeoutMs = (settings && settings.timeoutMs) || defaultTimeoutMs;
 
-            parambulator(remoteTransmitOptionsSpec).validate(settings || {}, function (err) {
-                if (err) {
-                    throw err;
-                }
-            });
-
-            _validateDestination(settings);
-
-            data = settings.data;
-
-            if (settings.destination64 || settings.destination16) {
-                return _remoteTransmitNoResponse(settings.destination64, settings.destination16, data);
+        parambulator(remoteTransmitOptionsSpec).validate(settings || {}, function (err) {
+            if (err) {
+                throw err;
             }
+        });
 
-            if (settings.destinationId) {
-                return _lookupByNodeIdentifier(settings.destinationId, timeoutMs)
-                    .then(function (lookupResult) {
-                        cachedNodes[settings.destinationId] = lookupResult;
-                        return _remoteTransmitNoResponse(lookupResult, undefined, data);
-                    });
-            }
+        _validateDestination(settings);
+
+        data = settings.data;
+
+        if (settings.destination64 || settings.destination16) {
+            return _remoteTransmitNoResponse(settings.destination64, settings.destination16, data);
         }
+
+        if (settings.destinationId) {
+            return _lookupByNodeIdentifier(settings.destinationId, timeoutMs)
+                .then(function (lookupResult) {
+                    cachedNodes[settings.destinationId] = lookupResult;
+                    return _remoteTransmitNoResponse(lookupResult, undefined, data);
+                });
+        }
+    }
 
 
     /**
@@ -591,8 +592,8 @@ module.exports = function xbeePromiseLibrary(options) {
         localCommand: localCommand,
         remoteCommand: remoteCommand,
         remoteTransmit: remoteTransmit,
-        remoteMonitor:remoteMonitor,
-        remoteTransmitNoResponse:remoteTransmitNoResponse,
+        remoteMonitor: remoteMonitor,
+        remoteTransmitNoResponse: remoteTransmitNoResponse,
         close: closeSerialport
     };
 

--- a/lib/xbee-promise.js
+++ b/lib/xbee-promise.js
@@ -285,8 +285,8 @@ module.exports = function xbeePromiseLibrary(options) {
 
         if (module === "802.15.4") {
             frame.type = destination64 ?
-            xbee_api.constants.FRAME_TYPE.TX_REQUEST_64 :
-            xbee_api.constants.FRAME_TYPE.TX_REQUEST_16;
+                xbee_api.constants.FRAME_TYPE.TX_REQUEST_64 :
+                xbee_api.constants.FRAME_TYPE.TX_REQUEST_16;
         }
         return frame;
     }
@@ -513,8 +513,8 @@ module.exports = function xbeePromiseLibrary(options) {
     }
 
     function remoteTransmitNoResponse(settings) {
-        var data;
-        var timeoutMs = (settings && settings.timeoutMs) || defaultTimeoutMs;
+        var data,
+            timeoutMs = (settings && settings.timeoutMs) || defaultTimeoutMs;
 
         parambulator(remoteTransmitOptionsSpec).validate(settings || {}, function (err) {
             if (err) {

--- a/lib/xbee-promise.js
+++ b/lib/xbee-promise.js
@@ -285,8 +285,8 @@ module.exports = function xbeePromiseLibrary(options) {
 
         if (module === "802.15.4") {
             frame.type = destination64 ?
-                xbee_api.constants.FRAME_TYPE.TX_REQUEST_64 :
-                xbee_api.constants.FRAME_TYPE.TX_REQUEST_16;
+                    xbee_api.constants.FRAME_TYPE.TX_REQUEST_64 :
+                    xbee_api.constants.FRAME_TYPE.TX_REQUEST_16;
         }
         return frame;
     }

--- a/lib/xbee-promise.js
+++ b/lib/xbee-promise.js
@@ -281,13 +281,12 @@ module.exports = function xbeePromiseLibrary(options) {
             type: xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_REQUEST,
             destination64: destination64,
             destination16: destination16
-        }
+        };
 
         if (module === "802.15.4") {
-            responseFrameType = xbee_api.constants.FRAME_TYPE.TX_STATUS;
-                frame.type = destination64 ?
-                xbee_api.constants.FRAME_TYPE.TX_REQUEST_64 :
-                xbee_api.constants.FRAME_TYPE.TX_REQUEST_16;
+            frame.type = destination64 ?
+            xbee_api.constants.FRAME_TYPE.TX_REQUEST_64 :
+            xbee_api.constants.FRAME_TYPE.TX_REQUEST_16;
         }
         return frame;
     }
@@ -307,6 +306,9 @@ module.exports = function xbeePromiseLibrary(options) {
         var frame = _buildRemoteTransmitFrame(destination64, destination16, data),
             responseFrameType = xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS;
 
+        if (module === "802.15.4") {
+            responseFrameType = xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS;
+        }
 
         if (debug) {
             console.log("Sending '" + data + "' to", destination64 || destination16);

--- a/lib/xbee-promise.js
+++ b/lib/xbee-promise.js
@@ -167,7 +167,7 @@ module.exports = function xbeePromiseLibrary(options) {
         xbeeAPI.on("frame_object", callback);
 
         // Return our promise with a termination step
-        return deferred.promise.fin(function() {
+        return deferred.promise.fin(function () {
             console.log("Stopped listening for network messages");
             xbeeAPI.removeListener("frame_object", callback);
         });
@@ -281,7 +281,7 @@ module.exports = function xbeePromiseLibrary(options) {
             type: xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_REQUEST,
             destination64: destination64,
             destination16: destination16
-        },
+        }
 
         if (module === "802.15.4") {
             responseFrameType = xbee_api.constants.FRAME_TYPE.TX_STATUS;
@@ -304,13 +304,13 @@ module.exports = function xbeePromiseLibrary(options) {
     function _remoteTransmit(destination64, destination16, data, timeoutMs) {
 
         // Get the transmit frame
-        var frame = _buildRemoteTransmitFrame(destination64, destination16, data);
+        var frame = _buildRemoteTransmitFrame(destination64, destination16, data),
+            responseFrameType = xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS;
+
 
         if (debug) {
             console.log("Sending '" + data + "' to", destination64 || destination16);
         }
-
-        var responseFrameType = xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS;
 
         return _sendFramePromiseResponse(frame, timeoutMs, responseFrameType)
             .then(function (frame) {

--- a/lib/xbee-promise.js
+++ b/lib/xbee-promise.js
@@ -77,6 +77,13 @@ module.exports = function xbeePromiseLibrary(options) {
     }
 
 
+    /**
+    * Create the callback monitoring the frameId and frame type
+    * @param deferred the deferred Q function
+    * @param frameId - the frame id to expect
+    * @param frameType the frame type to expect
+    * @return a callback to handle the message (resolve the promise)
+    */
     function _createCallback(deferred, frameId, frameType) {
         return function deferredResolverCallback(receivedFrame) {
             if (receivedFrame.id === frameId && receivedFrame.type === frameType) {
@@ -86,6 +93,36 @@ module.exports = function xbeePromiseLibrary(options) {
         };
     }
 
+    /**
+    * Create the callback monitoring a certain frame type
+    * @param deferred the deferred Q object
+    * @param frameType the frame type to look for
+    */
+    function _createMonitorCallback(deferred, frameType) {
+        return function deferredResolverCallback(receivedFrame) {
+            if (receivedFrame.type === frameType) {
+                // This is our frame's response. Resolve the promise.
+                deferred.resolve(receivedFrame);
+            }
+        };
+    }
+
+    /**
+    * Write to the serial port
+    * Note this may happen in the future if the port is not open
+    * @param frame the assembled frame compatible with xbee-api
+    *
+    */
+    function _sendFrame(frame) {
+        // Write to the serialport (when open or now if open)
+        if (serialport.paused) {
+            serialport.on("open", function () {
+                serialport.write(xbeeAPI.buildFrame(frame));
+            });
+        } else {
+            serialport.write(xbeeAPI.buildFrame(frame));
+        }
+    }
 
     // Returns a promise that will resolve to the response for the given
     // frame that will be sent.
@@ -102,17 +139,36 @@ module.exports = function xbeePromiseLibrary(options) {
         xbeeAPI.on("frame_object", callback);
 
         // Write to the serialport (when open or now if open)
-        if (serialport.paused) {
-            serialport.on("open", function () {
-                serialport.write(xbeeAPI.buildFrame(frame));
-            });
-        } else {
-            serialport.write(xbeeAPI.buildFrame(frame));
-        }
+        _sendFrame(frame);
 
         // Return our promise with a timeout
         return deferred.promise.timeout(timeoutMs).fin(function () {
             // clean up: remove listener after the promise is complete (for any reason)
+            xbeeAPI.removeListener("frame_object", callback);
+        });
+    }
+
+   /**
+    * Returns a promise that will resolve to the async message when it arrives
+    * This listens forever once resolved it is the callers' responsibility to
+    * restart the monitor.
+    * @param responseFrameType the type of frame to expect
+    */
+    function _monitorFramePromise(responseFrameType) {
+
+        var deferred = Q.defer();
+        var callback;
+
+        console.log("Waiting for network messages");
+        // Set the frame ID and create the callback to check for it
+        callback = _createMonitorCallback(deferred, responseFrameType);
+
+        // Attach callback so we're waiting for the response
+        xbeeAPI.on("frame_object", callback);
+
+        // Return our promise with a termination step
+        return deferred.promise.fin(function() {
+            console.log("Stopped listening for network messages");
             xbeeAPI.removeListener("frame_object", callback);
         });
     }
@@ -210,27 +266,46 @@ module.exports = function xbeePromiseLibrary(options) {
             });
     }
 
-
-    // Sends a the given data to the given destination.  A promise is
-    // returned that will resolve to 'true' on success or result in an
-    // Error with the failed status as the text.  Only one of
-    // destination64 or destination16 should be given; the other should
-    // be undefined.
-    function _remoteTransmit(destination64, destination16, data, timeoutMs) {
+    /**
+    * Build a frame for remote transmit using the 16 or 64 bit destination and the data
+    * Note: only one of destination64 or destination16 should be used
+    * @param destination64 the 64 bit destination address
+    * @param destination16 the 16 bit destination address
+    * @data the data packet to send
+    *
+    * @return the assembled frame
+    */
+    function _buildRemoteTransmitFrame(destination64, destination16, data) {
         var frame = {
-                data: data,
-                type: xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_REQUEST,
-                destination64: destination64,
-                destination16: destination16
-            },
-            responseFrameType = xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS;
+                    data: data,
+                    type: xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_REQUEST,
+                    destination64: destination64,
+                    destination16: destination16
+                },
+                responseFrameType = xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS;
 
-        if (module === "802.15.4") {
-            responseFrameType = xbee_api.constants.FRAME_TYPE.TX_STATUS;
-            frame.type = destination64 ?
-                    xbee_api.constants.FRAME_TYPE.TX_REQUEST_64 :
-                    xbee_api.constants.FRAME_TYPE.TX_REQUEST_16;
-        }
+            if (module === "802.15.4") {
+                responseFrameType = xbee_api.constants.FRAME_TYPE.TX_STATUS;
+                frame.type = destination64 ?
+                        xbee_api.constants.FRAME_TYPE.TX_REQUEST_64 :
+                        xbee_api.constants.FRAME_TYPE.TX_REQUEST_16;
+            };
+            return frame;
+    }
+
+    /**
+     * Sends a the given data packet to the given destination.
+     *
+     * @param destination64 the 64 bit address of the remote device
+     * @param destination16 the 16 bit address of the remote device
+     * Note: Only one of the destinations should be defined with the other one undefined
+     * @return A promise that will resolve to 'true' on success or result in an
+     *  error with the failed status as the text.
+     */
+    function _remoteTransmit(destination64, destination16, data, timeoutMs) {
+
+        // Get the transmit frame
+        var frame = _buildRemoteTransmitFrame(destination64, destination16, data);
 
         if (debug) {
             console.log("Sending '" + data + "' to", destination64 || destination16);
@@ -245,6 +320,48 @@ module.exports = function xbeePromiseLibrary(options) {
                 // if not OK, throw error
                 throw new Error(xbee_api.constants.DELIVERY_STATUS[frame.deliveryStatus]);
             });
+    }
+
+    /**
+     * Sends a the given data packet to the given destination without expecting a response
+     * Use this in conjunction with remoteMonitor to deal with asynchronous network messages
+     * Typical use case:
+     *   var me = this;
+     *   function handleMessage(message) {
+     *      // do something useful
+     *   }
+     *
+     *   function monitorNetwork() {
+     *
+     *      xbeePromise.remoteMonitor()
+     *          .then(function(message) {
+     *              me.handleMessage();
+     *          }).catch(function(err) {
+     *
+     *          }).fin(function() {
+     *              // restart the monitor
+     *              me.monitorNetwork();
+     *          });
+     *   };
+     *   // Get ready to receive
+     *   me.monitorNetwork();
+     *   // Assemble and send some data
+     *   xbeePromise.remoteTransmitNoResponse(remotedata);
+     *
+     * @param destination64 the 64 bit address of the remote device
+     * @param destination16 the 16 bit address of the remote device
+     * Note: Only one of the destinations should be defined with the other one undefined
+     */
+    function _remoteTransmitNoResponse(destination64, destination16, data, timeoutMs) {
+
+        // Get the transmit frame
+        var frame = _buildRemoteTransmitFrame(destination64, destination16, data);
+
+        if (debug) {
+            console.log("Sending '" + data + "' to", destination64 || destination16);
+        }
+
+        _sendFrame(frame);
     }
 
 
@@ -375,7 +492,7 @@ module.exports = function xbeePromiseLibrary(options) {
 
         _validateDestination(settings);
 
-        // TODO is there a miximum length for 'data'?
+        // TODO is there a maximum length for 'data'?
 
         data = settings.data;
 
@@ -392,6 +509,41 @@ module.exports = function xbeePromiseLibrary(options) {
         }
     }
 
+    function remoteTransmitNoResponse(settings) {
+            var data;
+            var timeoutMs = (settings && settings.timeoutMs) || defaultTimeoutMs;
+
+            parambulator(remoteTransmitOptionsSpec).validate(settings || {}, function (err) {
+                if (err) {
+                    throw err;
+                }
+            });
+
+            _validateDestination(settings);
+
+            data = settings.data;
+
+            if (settings.destination64 || settings.destination16) {
+                return _remoteTransmitNoResponse(settings.destination64, settings.destination16, data);
+            }
+
+            if (settings.destinationId) {
+                return _lookupByNodeIdentifier(settings.destinationId, timeoutMs)
+                    .then(function (lookupResult) {
+                        cachedNodes[settings.destinationId] = lookupResult;
+                        return _remoteTransmitNoResponse(lookupResult, undefined, data);
+                    });
+            }
+        }
+
+
+    /**
+    * Wait for a spontaneous message from the network or a response to a command when operating in
+    * asynchronous mode.
+    */
+    function remoteMonitor() {
+        return _monitorFramePromise(xbee_api.constants.FRAME_TYPE.ZIGBEE_RECEIVE_PACKET);
+    }
 
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Initialization
@@ -439,6 +591,8 @@ module.exports = function xbeePromiseLibrary(options) {
         localCommand: localCommand,
         remoteCommand: remoteCommand,
         remoteTransmit: remoteTransmit,
+        remoteMonitor:remoteMonitor,
+        remoteTransmitNoResponse:remoteTransmitNoResponse,
         close: closeSerialport
     };
 


### PR DESCRIPTION
Remote devices can generate their own events (ZIGBEE_TRANSMIT_REQUEST) without coordinator requests. There needs to be a means of monitoring them in a long running promise and resolving them when they occur. This first pass effort works but I have not extensively tested it with combined monitor/promise, transmit/promise situations. I think that they should co-exist since the serial port should dispatch to both and the monitor looks for frame.type===TRANSMIT_REQUEST messages from the remote device where as the transmit/promise matches against frame.type and frame.id. 

Added: 
- xbee-api.js
  -  remote monitor method 
  - remoteTransmitNoPromise method 
  - consolidate send and buildFrame functions
    Updated: 
- Readme.MD
  - Update to add methods
